### PR TITLE
Add support for parameterised ticket fetches, and add support for timesheet fetches

### DIFF
--- a/lib/freshdesk.rb
+++ b/lib/freshdesk.rb
@@ -54,7 +54,6 @@ class Freshdesk
           uri += '?' + URI.encode_www_form(args[0])
         end
       end
-      pp uri
       
       begin
         response = RestClient.get uri


### PR DESCRIPTION
This patch adds support for ticket fetches in 'hash' format, so that we can do filtered ticket fetches. So far as I can see, this should work correctly, but our use has been limited to only a few specific types of fetches.

It also adds support for fetching timesheets from Freshdesk.

Thanks for the useful library!
