### PR TITLE
Fix bug with passing in Fixnum argument

### DIFF
--- a/freshdesk.gemspec
+++ b/freshdesk.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'freshdesk'
-  s.version     = "0.4"
-  s.date        = '2014-02-14'
+  s.version     = "0.5"
+  s.date        = '2014-02-24'
   s.summary     = "Ruby Gem for interfacing with the Freshdesk API"
   s.description = "Ruby Gem for interfacing with the Freshdesk API"
   s.authors     = ["David Liman", "Tim Macdonald", "Jesse Pinho"]

--- a/lib/freshdesk.rb
+++ b/lib/freshdesk.rb
@@ -48,8 +48,8 @@ class Freshdesk
       # If we're supplied with a hash parameter, it means we're fetching
       # something like domain_URL/helpdesk/tickets.xml?filter_name=all_tickets&page=[value]
       if args.size > 0
-        if args[0].class == String
-          uri.gsub!(/\.#{response_format}/, "/#{args}\.#{response_format}")
+        if args[0].class == String || args[0].class == Fixnum
+          uri.gsub!(/\.#{response_format}/, "/#{args[0]}\.#{response_format}")
         else
           uri += '?' + URI.encode_www_form(args[0])
         end


### PR DESCRIPTION
I noticed the discussion in PR #4 about making sure the updates didn't break existing code that uses this gem; but when passing in Fixnum arguments to, say, `get_users`, the code does break. So I've added a check for Fixnum before assuming it's a hash.

Ultimately, this (and a number of other things, like the `response_format` handling) needs to be refactored. For example, I'm not sure we need a splat for `args`; why not just use the singular name `arg` and pass in a string, a number, or a hash? 
