### PR TITLE
Fix to allow custom fields when creating a ticket.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,10 @@ As of now, it supports the following:
 client = Freshdesk.new("http://companyname.freshdesk.com/", "user@domain.com", "password")  
 # note trailing slash in domain is required
 
+client = Freshdesk.new("http://companyname.freshdesk.com/", "api key")
+# simply lave out the password when specifiying the api key
+
+
 response = client.get_users  
 client.get_users 123  
 client.post_users(:name => "test", :email => "test@143124test.com", :customer => "name")  


### PR DESCRIPTION
custom fields and tags should now be possible when creating a ticket (sample below):

client.post_create_ticket(email: "joseph.dayo@gmail.com",
  phone: "+639277785XXX",
  twitter_id: 'josephdayo',
  description: "document follow-up",
  description_html: "document follow-up",
  subject: "document follow-up",
  ticket_type: "Existing Application",
  product_id: 9000000910,
  status: Freshdesk::Ticket::STATUS_OPEN,
  group_id: 9000083657,
  priority: Freshdesk::Ticket::PRIORITY_LOW,
  custom_field: {
    source_313839: "Verification",
    user_id_313839: 1234567,
    loan_id_313839: 1234534,
  },
  tags: 'doc,follow,up'
)

It is unclear based on freshdesk's docs on how to add tags to tickets using XML in freshdesk, thus the json version